### PR TITLE
fix: Show the select item of  layout 4

### DIFF
--- a/src/app/layouts/index.tsx
+++ b/src/app/layouts/index.tsx
@@ -413,7 +413,7 @@ export const allLayoutLabels = {
   Layout1: "Grid 1",
   Layout2: "Grid 2",
   Layout3: "Grid 3",
-  // Layout4: "Blocks 1",
+  Layout4: "Blocks 1",
 }
 
 // note for reference: A4 (297mm x 210mm)


### PR DESCRIPTION
Before:

<img width="273" alt="image" src="https://github.com/jbilcke-hf/ai-comic-factory/assets/5910926/c5cb9dd6-9957-43ba-a0ff-1d562c36a7b9">

after:

<img width="1721" alt="image" src="https://github.com/jbilcke-hf/ai-comic-factory/assets/5910926/cbd3d34f-0f00-4790-b40a-b51c219295a1">
Hi, I am terry, an enthusiastic comic fan and I'm interested in contributing to the open-source development of the jbilcke-hf/ai-comic-factory project. I've noticed there's a minor UI issue with the layout selection, and I'd like to attempt to submit a PR to fix it.